### PR TITLE
Add extra URLs feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,10 @@ Ensure you have Python 3.9 installed, as well as pipenv. Then run the following:
 
     pipenv install
     pipenv run scrapy runspider scraper.py -o ./output/output.json -o ./output/output.csv
+
+By default, this spider will crawl the homepage only. If you also have extra urls to crawl these can be passed as an argument. For example, to also crawl all news items, even unreachable ones, you can export them from the Contentful API and add these:
+
+    contentful space export ...
+    jq -rc '.entries | [.[] | select(.sys.contentType.sys.id | contains("news")) | ("https://www.essex.gov.uk/news/" + .fields.slug["en-GB"])]' < contentful-export.json > extra_urls.json
+    pipenv install
+    pipenv run scrapy runspider scraper.py -o ./output/output.json -o ./output/output.csv -a extra_urls_file=/Users/mwilkes/play/ecc/extra_urls.json

--- a/scraper.py
+++ b/scraper.py
@@ -1,3 +1,4 @@
+import json
 from urllib.parse import urlparse
 import scrapy
 
@@ -10,6 +11,12 @@ class AssetSpider(scrapy.Spider):
     start_urls = [
         'https://www.essex.gov.uk/'
     ]
+
+    def __init__(self, extra_urls_file=None, *args, **kwargs):
+        super(*args, **kwargs)
+        if extra_urls_file is not None:
+            with open(extra_urls_file, "rt", encoding="utf-8") as urls_file:
+                self.start_urls += json.load(urls_file)
 
     def parse(self, response):
         # Introspect all tags with an src or an href attribute for the target domain

--- a/scraper.py
+++ b/scraper.py
@@ -11,6 +11,9 @@ class AssetSpider(scrapy.Spider):
     start_urls = [
         'https://www.essex.gov.uk/'
     ]
+    allowed_domains = [
+        "www.essex.gov.uk"
+    ]
 
     custom_settings = {
         'AUTOTHROTTLE_ENABLED': True,
@@ -43,5 +46,8 @@ class AssetSpider(scrapy.Spider):
             if FOLLOW_DOMAIN in link or relative:
                 if '?' in link:
                     # Skip parameterised requests
+                    continue
+                if link.endswith(".pdf"):
+                    # Skip things that are obviously assets
                     continue
                 yield response.follow(link, callback=self.parse)

--- a/scraper.py
+++ b/scraper.py
@@ -12,6 +12,11 @@ class AssetSpider(scrapy.Spider):
         'https://www.essex.gov.uk/'
     ]
 
+    custom_settings = {
+        'AUTOTHROTTLE_ENABLED': True,
+        'AUTOTHROTTLE_TARGET_CONCURRENCY': 0.25,
+    }
+
     def __init__(self, extra_urls_file=None, *args, **kwargs):
         super(*args, **kwargs)
         if extra_urls_file is not None:


### PR DESCRIPTION
This allows users to specify a JSON file containing other start URLs, useful for pre-loading the news items into the crawl queue as older items aren't reachable from the homepage.

Also:

 - Enable auto-throttle to be kinder on the site